### PR TITLE
fix: set sitemap to 'noindex'

### DIFF
--- a/web/src/routes/sitemap.xml/+server.ts
+++ b/web/src/routes/sitemap.xml/+server.ts
@@ -30,7 +30,8 @@ export const GET: RequestHandler = async () => {
     {
       headers: {
         'Content-Type': 'application/xml',
-        'Cache-Control': 'max-age=0, s-maxage=3600'
+        'Cache-Control': 'max-age=0, s-maxage=3600', 
+        'X-Robots-Tag': 'noindex'
       }
     }
   );


### PR DESCRIPTION
Set HTTP header 'X-Robots-Tag' to 'noindex' to prevent the sitemap from being indexed and showing up in Google search results. 