### PR TITLE
feat: parse description with doi-links

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Therefore we decided to develop a new user interface with search capabilities, t
 
 # Structure
 
-This repo currently only uses the `web`-directory for the PWA codebase. Subsequent releases will introduce more apps (e.g. for Android or Windows) w/ their respective directories.
+This repo uses the `web`-directory for the PWA codebase. Isolated backend services are located in the `services`-directory. The `web`-directory is a SvelteKit project. The `services`-directory contains different backend-only services that can be deployed on different platforms.
 
 <br />
 <br />

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,11 +11,11 @@
         "@lokidb/indexed-storage": "2.1.0",
         "@lokidb/loki": "2.1.0",
         "@rgossiaux/svelte-headlessui": "^1.0.2",
-        "comlink": "^4.3.1",
-        "date-fns": "^2.29.3",
-        "fuse.js": "^6.6.2",
-        "idb": "^7.1.1",
-        "idb-keyval": "^6.2.0"
+        "comlink": "4.3.1",
+        "date-fns": "2.29.3",
+        "fuse.js": "6.6.2",
+        "idb": "7.1.1",
+        "idb-keyval": "6.2.0"
       },
       "devDependencies": {
         "@faker-js/faker": "7.5.0",

--- a/web/package.json
+++ b/web/package.json
@@ -61,10 +61,10 @@
     "@lokidb/indexed-storage": "2.1.0",
     "@lokidb/loki": "2.1.0",
     "@rgossiaux/svelte-headlessui": "^1.0.2",
-    "comlink": "^4.3.1",
-    "date-fns": "^2.29.3",
-    "fuse.js": "^6.6.2",
-    "idb": "^7.1.1",
-    "idb-keyval": "^6.2.0"
+    "comlink": "4.3.1",
+    "date-fns": "2.29.3",
+    "fuse.js": "6.6.2",
+    "idb": "7.1.1",
+    "idb-keyval": "6.2.0"
   }
 }

--- a/web/src/lib/blocks/views/ContactCard.svelte
+++ b/web/src/lib/blocks/views/ContactCard.svelte
@@ -21,22 +21,12 @@
   </p>
   <div class="flex space-x-2">
     {#if socials.linkedin}
-      <Link
-        href={socials.linkedin}
-        target="_blank"
-        rel="noopener noreferrer"
-        ariaLabel="LinkedIn account URL"
-      >
+      <Link href={socials.linkedin} target="_blank" rel="noopener" ariaLabel="LinkedIn account URL">
         <Iconic name="carbon:logo-linkedin" size="32" />
       </Link>
     {/if}
     {#if socials.github}
-      <Link
-        href={socials.github}
-        target="_blank"
-        rel="noopener noreferrer"
-        ariaLabel="Email address"
-      >
+      <Link href={socials.github} target="_blank" rel="noopener" ariaLabel="Email address">
         <Iconic name="carbon:logo-github" size="32" />
       </Link>
     {/if}
@@ -44,7 +34,7 @@
       <Link
         href={`mailto:${socials.email}`}
         target="_blank"
-        rel="noopener noreferrer"
+        rel="noopener"
         ariaLabel="Email address"
       >
         <Iconic name="carbon:email" size="32" />

--- a/web/src/lib/blocks/views/SubGridIcon.svelte
+++ b/web/src/lib/blocks/views/SubGridIcon.svelte
@@ -12,7 +12,7 @@
     ariaLabel="Link to {meta.url}"
     title="Link to {meta.url}"
     target={meta.isExternal ? '_blank' : undefined}
-    rel={meta.isExternal ? 'noopener noreferrer' : undefined}
+    rel={meta.isExternal ? 'noopener' : undefined}
   >
     <Iconic name={meta.icon || 'carbon:arrow-up-right'} />
   </Link>

--- a/web/src/lib/display/views/Link.svelte
+++ b/web/src/lib/display/views/Link.svelte
@@ -6,7 +6,7 @@
   export let ariaLabel: string | undefined = undefined;
   export let title: string | undefined = undefined;
   export let target: string | undefined = undefined;
-  export let rel: 'noopener noreferrer' | undefined = undefined;
+  export let rel: 'noopener' | undefined = undefined;
   export let withForcedReload: true | undefined = undefined;
 
   let cn: string | undefined = undefined;

--- a/web/src/lib/license/views/LicensesList.svelte
+++ b/web/src/lib/license/views/LicensesList.svelte
@@ -11,7 +11,7 @@
       <Link
         href={l.link.replace('git+', '').replace('.git', '')}
         ariaLabel={`License for ${l.name}`}
-        rel="noopener noreferrer"
+        rel="noopener"
         target="_blank"
       >
         <div class="hover:text-neutral-400 duration-200 ease-in-out py-3 space-x-2">

--- a/web/src/routes/about/+page.svelte
+++ b/web/src/routes/about/+page.svelte
@@ -161,7 +161,7 @@
             <strong>CRAN/E</strong> uses <Link
               href="https://plausible.io/"
               target="_blank"
-              rel="noopener noreferrer">plausible.io</Link
+              rel="noopener">plausible.io</Link
             > for a privacy-friendly, non-invasive way to collect some basic usage data of this PWA.
             This analytics service is hosted in the EU and doesn't collect any personal identifiable
             data. This is also the reason why you don't see a cookie-banner - we simply don't need consent
@@ -178,7 +178,7 @@
           <SubGrid class="not-prose">
             <SubGridItem key="Link" url="https://plausible.io">
               <div>plausible.io</div>
-              <Link href="https://plausible.io" target="_blank" rel="noopener noreferrer">
+              <Link href="https://plausible.io" target="_blank" rel="noopener">
                 <Iconic name="simple-icons:plausibleanalytics" size="20" />
               </Link>
             </SubGridItem>
@@ -208,10 +208,8 @@
             </p>
             <p>
               If you want to support us, you can do so by donating to our
-              <Link
-                href="https://buymeacoffee.com/v5728ggzwfI"
-                target="_blank"
-                rel="noopener noreferrer">BuyMeACoffee</Link
+              <Link href="https://buymeacoffee.com/v5728ggzwfI" target="_blank" rel="noopener"
+                >BuyMeACoffee</Link
               >.
             </p>
           </div>
@@ -222,18 +220,14 @@
               <Link
                 href="https://github.com/flaming-codes/crane-app"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener"
               >
                 <Iconic name="carbon:logo-github" />
               </Link>
             </SubGridItem>
             <SubGridItem key="Sponsor" withSpaceY="xs">
               <span>Buy-me-a-coffee</span>
-              <Link
-                href="https://buymeacoffee.com/v5728ggzwfI"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
+              <Link href="https://buymeacoffee.com/v5728ggzwfI" target="_blank" rel="noopener">
                 <Iconic name="carbon:piggy-bank-slot" />
               </Link>
             </SubGridItem>
@@ -298,7 +292,7 @@
                 href="https://cran.r-project.org/bin/linux/"
                 ariaLabel="Downloads for Linux"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener"
               >
                 <Iconic name="carbon:arrow-up-right" />
               </Link>
@@ -326,7 +320,7 @@
               <Link
                 href="https://www.rstudio.com/"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener"
                 ariaLabel="RStudio link"
               >
                 <Iconic name="carbon:arrow-up-right" />

--- a/web/src/routes/author/[id]/+page.svelte
+++ b/web/src/routes/author/[id]/+page.svelte
@@ -150,7 +150,7 @@
                   ariaLabel="More information about {id}"
                   class="space-y-1"
                   target="_blank"
-                  rel="noopener noreferrer"
+                  rel="noopener"
                 >
                   <div>{link.replace('https://orcid.org/', '')}</div>
                   <Iconic

--- a/web/src/routes/package/[id]/+page.server.ts
+++ b/web/src/routes/package/[id]/+page.server.ts
@@ -39,6 +39,13 @@ export const load: PageServerLoad = async ({ params }) => {
   item.macos_binaries = parseMacOsBinaries(item);
   item.windows_binaries = parseWindowsBinaries(item);
 
+  // Replace the stringified DOIs with links.
+  const doiRegex = /<doi:([^>]+)>/g;
+  item.description = item.description.replace(
+    doiRegex,
+    '<a href="https://doi.org/$1" target="_blank" alt="Link to DOI $1">doi:$1</a>'
+  );
+
   const downloads = await getDownloadsWithTrends(item);
 
   const dependencyGroups = [

--- a/web/src/routes/package/[id]/+page.svelte
+++ b/web/src/routes/package/[id]/+page.svelte
@@ -152,7 +152,7 @@
 
       <PackageDetailSection title="About" id="about">
         <p class="prose prose-lg prose-invert max-w-none">
-          {item.description}
+          {@html item.description}
         </p>
         <SubGrid>
           {#each aboutItems as [key, value, meta]}
@@ -289,7 +289,7 @@
                       href={link}
                       ariaLabel="Link for {name}"
                       title="Link for {name}"
-                      rel="noopener noreferrer"
+                      rel="noopener"
                       target="_blank"
                       class="text-white"
                     >
@@ -338,7 +338,7 @@
               <SubGridItem key={name} withSpaceY="md">
                 <Link
                   href={link}
-                  rel={type !== 'download' ? 'noopener noreferrer' : undefined}
+                  rel={type !== 'download' ? 'noopener' : undefined}
                   target={type !== 'download' ? '_blank' : undefined}
                   ariaLabel="Link to {name}"
                   class="block"
@@ -358,7 +358,7 @@
               <SubGridItem key={name} withSpaceY="md">
                 <Link
                   href={link}
-                  rel="noopener noreferrer"
+                  rel="noopener"
                   target="_blank"
                   class="block"
                   ariaLabel="Open inview to {link}"
@@ -379,7 +379,7 @@
                 <SubGridItem withKeyTruncate key={link.replace('https://', '')} withSpaceY="md">
                   <Link
                     href={link}
-                    rel="noopener noreferrer"
+                    rel="noopener"
                     target="_blank"
                     class="block"
                     ariaLabel="Open repo repo"
@@ -393,7 +393,7 @@
                 <SubGridItem key={name} withSpaceY="md">
                   <Link
                     href={link}
-                    rel="noopener noreferrer"
+                    rel="noopener"
                     target="_blank"
                     class="block"
                     ariaLabel="Open repo {name}"
@@ -414,7 +414,7 @@
               <SubGridItem key={name} withSpaceY="md">
                 <Link
                   href={link}
-                  rel="noopener noreferrer"
+                  rel="noopener"
                   target="_blank"
                   ariaLabel="Vignette link to {name}"
                   class="block"


### PR DESCRIPTION
### Goals

- transform stringified `<doi:...>` links to valid `<a href=...>`
- remove invalid `noreferrer` from `Link`