### PR TITLE
feat: search cache

### DIFF
--- a/web/app/data/package.service.ts
+++ b/web/app/data/package.service.ts
@@ -31,10 +31,15 @@ export class PackageService {
     ttl: hoursToMilliseconds(6),
   });
 
-  /** Specific cache for search hits by query as key. */
+  /**
+   * Specific cache for search hits by query as key.
+   * ! This is a global cache on the server for all users.
+   * Not an issue as the search results are not user-specific,
+   * but it's important to keep in mind.
+   * */
   private static cachedHits = new TTLCache<string, SearchResult>({
     ttl: minutesToMilliseconds(5),
-    max: 500,
+    max: 100,
   });
 
   private static readonly sitemapDivisor = 1000;

--- a/web/app/data/package.service.ts
+++ b/web/app/data/package.service.ts
@@ -7,8 +7,8 @@ import { authorIdSchema } from "./author.shape";
 import { groupBy, omit, uniqBy } from "es-toolkit";
 import TTLCache from "@isaacs/ttlcache";
 import { format, hoursToMilliseconds } from "date-fns";
-import { embed } from "ai";
-import { google } from "@ai-sdk/google";
+// import { embed } from "ai";
+// import { google } from "@ai-sdk/google";
 
 type Package = Tables<"cran_packages">;
 
@@ -180,16 +180,18 @@ export class PackageService {
           .select("id,name,synopsis")
           .ilike("name", query)
           .maybeSingle(),
-        isSimilaritySearchEnabled
-          ? supabase.rpc("match_package_embeddings", {
-              query_embedding: await embed({
-                value: query,
-                model: google.textEmbeddingModel("text-embedding-004"),
-              }).then((res) => res.embedding as unknown as string),
-              match_threshold: 0.4,
-              match_count: limit,
-            })
-          : null,
+        // TODO: Embedding search disabled until DB performance is improved.
+        // isSimilaritySearchEnabled
+        //   ? supabase.rpc("match_package_embeddings", {
+        //       query_embedding: await embed({
+        //         value: query,
+        //         model: google.textEmbeddingModel("text-embedding-004"),
+        //       }).then((res) => res.embedding as unknown as string),
+        //       match_threshold: 0.4,
+        //       match_count: limit,
+        //     })
+        //   : null,
+        { data: [], error: null },
         isSimilaritySearchEnabled
           ? supabase.rpc("find_closest_package_embeddings", {
               search_term: query,

--- a/web/app/data/package.service.ts
+++ b/web/app/data/package.service.ts
@@ -6,7 +6,8 @@ import { slog } from "../modules/observability.server";
 import { authorIdSchema } from "./author.shape";
 import { groupBy, omit, uniqBy } from "es-toolkit";
 import TTLCache from "@isaacs/ttlcache";
-import { format, hoursToMilliseconds } from "date-fns";
+import { format, hoursToMilliseconds, minutesToMilliseconds } from "date-fns";
+
 // import { embed } from "ai";
 // import { google } from "@ai-sdk/google";
 
@@ -16,9 +17,24 @@ type CacheKey = "sitemap-items";
 
 type CacheValue = SitemapItem[];
 
+type SearchResult = {
+  combined: Array<{
+    name: string;
+    synopsis: string;
+  } | null>;
+  isSemanticPreferred: boolean;
+};
+
 export class PackageService {
+  /** Cache for singular domains, e.g. the sitemap. */
   private static cache = new TTLCache<CacheKey, CacheValue>({
     ttl: hoursToMilliseconds(6),
+  });
+
+  /** Specific cache for search hits by query as key. */
+  private static cachedHits = new TTLCache<string, SearchResult>({
+    ttl: minutesToMilliseconds(5),
+    max: 500,
   });
 
   private static readonly sitemapDivisor = 1000;
@@ -168,6 +184,11 @@ export class PackageService {
 
     const isSimilaritySearchEnabled = query.length >= 3;
 
+    const cached = this.cachedHits.get(query);
+    if (cached) {
+      return cached;
+    }
+
     const [packageFTS, packageExact, embeddingSimilarity, embeddingFTS] =
       await Promise.all([
         supabase.rpc("find_closest_packages", {
@@ -298,14 +319,15 @@ export class PackageService {
     const isSemanticPreferred =
       !packageExact.data && isSimilaritySearchEnabled && sources.length > 0;
 
-    return {
-      lexical,
-      semantic: groupedSourcesByPackage,
+    const result: SearchResult = {
       combined: isSemanticPreferred
         ? [...groupedSourcesByPackage, ...lexical]
         : [...lexical, ...groupedSourcesByPackage],
       isSemanticPreferred,
     };
+
+    this.cachedHits.set(query, result);
+    return result;
   }
 
   private static sanitizeSitemapName(name: string) {

--- a/web/app/modules/search.hit.tsx
+++ b/web/app/modules/search.hit.tsx
@@ -9,7 +9,7 @@ import {
   RiMarkdownFill,
 } from "@remixicon/react";
 
-export type BaseSearchHit = { id: number; name: string; synopsis?: string };
+export type BaseSearchHit = { id?: number; name: string; synopsis?: string };
 
 export type PackageSemanticSearchHit = BaseSearchHit & {
   sources: Array<

--- a/web/app/routes/api.search._index.ts
+++ b/web/app/routes/api.search._index.ts
@@ -28,8 +28,6 @@ export const action: ActionFunction = async ({ request }) => {
         ? packages.value
         : {
             combined: [],
-            lexical: [],
-            semantic: [],
             isSemanticPreferred: false,
           };
     const authorHits = authors.status === "fulfilled" ? authors.value : [];

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "sideEffects": false,
   "type": "module",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "scripts": {
     "postinstall": "npm run licenses.build",
     "postuninstall": "npm run licenses.build",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds caching for search results in `PackageService` and disables embedding search for performance, with minor type and version updates.
> 
>   - **Caching**:
>     - Adds `cachedHits` in `PackageService` to cache search results for 5 minutes.
>     - Checks cache before performing search in `searchPackages()`.
>   - **Code Changes**:
>     - Disables embedding search in `searchPackages()` for performance reasons.
>     - Removes unused imports in `package.service.ts`.
>   - **Type Adjustments**:
>     - Makes `id` optional in `BaseSearchHit` in `search.hit.tsx`.
>   - **Misc**:
>     - Updates version in `package.json` from `2.7.3` to `2.7.4`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flaming-codes%2Fcrane-app&utm_source=github&utm_medium=referral)<sup> for 1b8362cd9b5538783d1d0eb667472123566bbea6. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->