### PR TITLE
feat: update server logging

### DIFF
--- a/web/app/modules/observability.server.ts
+++ b/web/app/modules/observability.server.ts
@@ -1,18 +1,56 @@
-import { createLogger, format, transports } from "winston";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { logs } from "@opentelemetry/api-logs";
+import {
+  LoggerProvider,
+  SimpleLogRecordProcessor,
+  ConsoleLogRecordExporter,
+} from "@opentelemetry/sdk-logs";
+import { registerInstrumentations } from "@opentelemetry/instrumentation";
+import { WinstonInstrumentation } from "@opentelemetry/instrumentation-winston";
+import * as winston from "winston";
+import { Resource } from "@opentelemetry/resources";
+import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
+import { ENV } from "../data/env";
+import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
 
-export const slog = createLogger({
-  format: format.combine(
-    format.timestamp(),
-    format.printf(({ timestamp, label, level, message }) => {
-      return `${timestamp} ${label} ${level}: ${message}`;
-    }),
-  ),
+const serviceName = "crane-app";
+
+const resource = new Resource({
+  [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
 });
 
-if (process.env.NODE_ENV === "production") {
-  slog.add(new transports.Console({ format: format.json() }));
-} else if (process.env.NODE_ENV === "test") {
-  slog.add(new transports.Console({ format: format.errors() }));
-} else {
-  slog.add(new transports.Console({ format: format.simple() }));
-}
+const otlpExporter = new OTLPLogExporter({
+  url: process.env.OTEL_TRACE_URL,
+});
+
+const tracerProvider = new NodeTracerProvider({ resource });
+tracerProvider.register();
+
+const loggerProvider = new LoggerProvider({ resource });
+
+// Configure the logger provider with a processor and exporter
+loggerProvider.addLogRecordProcessor(
+  new SimpleLogRecordProcessor(
+    ENV.OTEL_ENABLED === "true" ? otlpExporter : new ConsoleLogRecordExporter(),
+  ),
+);
+
+// Set the global logger provider
+logs.setGlobalLoggerProvider(loggerProvider);
+
+registerInstrumentations({
+  instrumentations: [
+    new WinstonInstrumentation({
+      enabled: ENV.OTEL_ENABLED === "true",
+      // Also set the resource here if needed for instrumentation-specific resources
+      // resource: resource
+    }),
+  ],
+});
+
+const logger = winston.createLogger({
+  transports: [new winston.transports.Console()],
+  format: winston.format.json(),
+});
+
+export const slog = logger;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update server logging in `observability.server.ts` to use OpenTelemetry for enhanced observability and instrumentation.
> 
>   - **Logging Update**:
>     - Replaces Winston logger setup with OpenTelemetry in `observability.server.ts`.
>     - Introduces `NodeTracerProvider`, `LoggerProvider`, and `WinstonInstrumentation` for enhanced logging.
>     - Configures `LoggerProvider` with `SimpleLogRecordProcessor` and `OTLPLogExporter` or `ConsoleLogRecordExporter` based on `ENV.OTEL_ENABLED`.
>     - Registers global logger provider and instrumentations.
>   - **Resource Configuration**:
>     - Sets `serviceName` to "crane-app" and configures `Resource` with `SemanticResourceAttributes.SERVICE_NAME`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flaming-codes%2Fcrane-app&utm_source=github&utm_medium=referral)<sup> for a69dafb48b7a3fc503230512c60080c7583bef0d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->